### PR TITLE
Fix fail safe

### DIFF
--- a/django_pwned_passwords/password_validation.py
+++ b/django_pwned_passwords/password_validation.py
@@ -58,6 +58,8 @@ class PWNEDPasswordValidator(object):
                 return VALID
             elif response.status_code in [400, 429, 500]:
                 raise ValidationError(self.error_fail_msg)
+            elif response.status_code in [200]:
+                return VALID
         except requests.exceptions.RequestException:
             if not self.fail_safe:
                 raise ValidationError(self.error_fail_msg)

--- a/tests/test_password_validation.py
+++ b/tests/test_password_validation.py
@@ -144,6 +144,19 @@ class TestPasswordValidation(TestCase):
 
     @requests_mock.mock()
     @override_settings(PWNED_VALIDATOR_FAIL_SAFE=False)
+    def test_not_fail_safe_redirect_fails(self, m):
+        validator = PWNEDPasswordValidator()
+        password = "supersecret"
+        p_hash = self.get_hash(password)
+        short_hash = p_hash.upper()[:5]
+
+        m.get(validator.url.format(short_hash=short_hash), status_code=301)
+
+        with self.assertRaises(ValidationError):
+            validator.validate(password)
+
+    @requests_mock.mock()
+    @override_settings(PWNED_VALIDATOR_FAIL_SAFE=False)
     def test_not_fail_safe_unpwned_password_succeeds(self, m):
         validator = PWNEDPasswordValidator()
         password = "supersecret"

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,10 @@
 [tox]
 envlist =
-    {py27,py34,py35,py36}-django-18
-    {py27,py34,py35,py36}-django-19
-    {py27,py34,py35,py36}-django-110
-    {py27,py34,py35,py36}-django-111
-    {py34,py35,py36}-django-20
+    {py27,py34,py35,py36,py37}-django-18
+    {py27,py34,py35,py36,py37}-django-19
+    {py27,py34,py35,py36,py37}-django-110
+    {py27,py34,py35,py36,py37}-django-111
+    {py34,py35,py36,py37}-django-20
 
 [testenv]
 setenv =
@@ -21,6 +21,7 @@ deps =
     -r{toxinidir}/requirements_test.txt
 
 basepython =
+    py37: python3.7
     py36: python3.6
     py35: python3.5
     py34: python3.4


### PR DESCRIPTION
In the new api, every range query returns status 200 and in non fail-safe, valid was never returned. Now the password is valid, if the API returned a status of 200 and the hash was not contained in the body